### PR TITLE
Add string manipulation functions for database dialects

### DIFF
--- a/packages/prisma-ts-select/README.md
+++ b/packages/prisma-ts-select/README.md
@@ -1063,6 +1063,37 @@ prisma.$from("User")
       .select(({ sum }) => sum("User.age"), "total");
 ```
 
+#### String Functions (all dialects)
+
+| Function | SQL | Returns |
+|---|---|---|
+| `upper(col)` | `UPPER(col)` | `string` |
+| `lower(col)` | `LOWER(col)` | `string` |
+| `length(col)` | `LENGTH(col)` | `number` |
+| `trim(col)` | `TRIM(col)` | `string` |
+| `ltrim(col)` | `LTRIM(col)` | `string` |
+| `rtrim(col)` | `RTRIM(col)` | `string` |
+| `replace(col, from, to)` | `REPLACE(col, 'from', 'to')` | `string` |
+
+> **Note:** MySQL `LENGTH()` returns byte-length (not char-length). For character-length on multi-byte strings use a dialect-specific fn.
+
+```typescript file=../usage-sqlite-v7/tests/readme/select-fns.ts region=upper
+prisma.$from("User")
+      .select(({ upper }) => upper("User.name"), "uname");
+```
+
+String fns accept a `SQLExpr<string>` as input, enabling composition:
+
+```typescript file=../usage-sqlite-v7/tests/readme/select-fns.ts region=lower
+prisma.$from("User")
+      .select(({ lower }) => lower("User.name"), "lname");
+```
+
+```typescript file=../usage-sqlite-v7/tests/readme/select-fns.ts region=replace
+prisma.$from("User")
+      .select(({ replace }) => replace("User.email", "@example.com", ""), "handle");
+```
+
 #### Combining with `.groupBy()`
 
 ```typescript file=../usage-sqlite-v7/tests/readme/select-fns.ts region=count-groupby
@@ -1097,6 +1128,16 @@ GROUP BY User.name;
 | `varSamp(col)` | `VAR_SAMP(col)` | `number` |
 | `jsonArrayAgg(col)` | `JSON_ARRAYAGG(col)` | `JSONValue` |
 | `jsonObjectAgg(key, val)` | `JSON_OBJECTAGG(key, val)` | `JSONValue` |
+| `concat(...cols)` | `CONCAT(a, b, ...)` | `string` |
+| `substring(col, start, len?)` | `SUBSTRING(col, start, len)` | `string` |
+| `left(col, n)` | `LEFT(col, n)` | `string` |
+| `right(col, n)` | `RIGHT(col, n)` | `string` |
+| `repeat(col, n)` | `REPEAT(col, n)` | `string` |
+| `reverse(col)` | `REVERSE(col)` | `string` |
+| `lpad(col, len, pad)` | `LPAD(col, len, 'pad')` | `string` |
+| `rpad(col, len, pad)` | `RPAD(col, len, 'pad')` | `string` |
+| `locate(substr, col)` | `LOCATE('substr', col)` | `number` |
+| `space(n)` | `SPACE(n)` | `string` |
 
 > **Note:** `jsonArrayAgg` and `jsonObjectAgg` require MySQL 5.7.22+.
 
@@ -1118,6 +1159,19 @@ GROUP BY User.name;
 | `bitAnd(col)` | `BIT_AND(col)` | `number` |
 | `bitOr(col)` | `BIT_OR(col)` | `number` |
 | `jsonObjectAgg(key, val)` | `JSON_OBJECT_AGG(key, val)` | `JSONValue` |
+| `concat(...cols)` | `CONCAT(a, b, ...)` | `string` |
+| `substring(col, start, len?)` | `SUBSTRING(col, start, len)` | `string` |
+| `left(col, n)` | `LEFT(col, n)` | `string` |
+| `right(col, n)` | `RIGHT(col, n)` | `string` |
+| `repeat(col, n)` | `REPEAT(col, n)` | `string` |
+| `reverse(col)` | `REVERSE(col)` | `string` |
+| `lpad(col, len, pad)` | `LPAD(col, len, 'pad')` | `string` |
+| `rpad(col, len, pad)` | `RPAD(col, len, 'pad')` | `string` |
+| `initcap(col)` | `INITCAP(col)` | `string` |
+| `strpos(col, substr)` | `STRPOS(col, 'substr')` | `number` |
+| `splitPart(col, delimiter, field)` | `SPLIT_PART(col, 'delimiter', field)` | `string` |
+| `btrim(col, chars?)` | `BTRIM(col)` / `BTRIM(col, 'chars')` | `string` |
+| `md5(col)` | `MD5(col)` | `string` |
 
 ---
 
@@ -1127,8 +1181,14 @@ GROUP BY User.name;
 |---|---|---|
 | `groupConcat(col, sep?)` | `GROUP_CONCAT(col, sep)` | `string` |
 | `total(col)` | `TOTAL(col)` | `number` |
+| `concat(...cols)` | `a \|\| b \|\| ...` | `string` |
+| `substr(col, start, len?)` | `SUBSTR(col, start, len)` | `string` |
+| `instr(col, substr)` | `INSTR(col, 'substr')` | `number` |
+| `char(...codes)` | `CHAR(n1, n2, ...)` | `string` |
+| `hex(col)` | `HEX(col)` | `string` |
+| `unicode(col)` | `UNICODE(col)` | `number` |
 
-> **Note:** `total()` behaves like `SUM()` but returns `0.0` instead of `NULL` for empty sets.
+> **Note:** `total()` behaves like `SUM()` but returns `0.0` instead of `NULL` for empty sets. SQLite uses the `||` operator for string concatenation.
 
 ---
 
@@ -1136,7 +1196,6 @@ GROUP BY User.name;
 
 - Support specifying `JOIN` type [issue#2](https://github.com/adrianbrowning/prisma-ts-select/issues/2)
 - Support additional Select Functions
-  - [String #5](https://github.com/adrianbrowning/prisma-ts-select/issues/5)
   - [Date & Time #6](https://github.com/adrianbrowning/prisma-ts-select/issues/6)
   - [Math #7](https://github.com/adrianbrowning/prisma-ts-select/issues/7)
   - [Control Flow #8](https://github.com/adrianbrowning/prisma-ts-select/issues/8)

--- a/packages/prisma-ts-select/src/dialects/mysql.ts
+++ b/packages/prisma-ts-select/src/dialects/mysql.ts
@@ -22,6 +22,26 @@ export const mysqlContextFns = <TCol extends string = string>(quoteFn: (ref: str
   jsonArrayAgg:  (col: TCol): SQLExpr<JSONValue> => sqlExpr(`JSON_ARRAYAGG(${quoteFn(col)})`),
   jsonObjectAgg: (key: TCol, val: TCol): SQLExpr<JSONValue> =>
     sqlExpr(`JSON_OBJECTAGG(${quoteFn(key)}, ${quoteFn(val)})`),
+  concat: (...args: Array<TCol | SQLExpr<string>>): SQLExpr<string> =>
+    sqlExpr(`CONCAT(${args.map(a => resolveArg(a, quoteFn)).join(', ')})`),
+  substring: (col: TCol | SQLExpr<string>, start: number, len?: number): SQLExpr<string> =>
+    sqlExpr(`SUBSTRING(${resolveArg(col, quoteFn)}, ${start}${len !== undefined ? `, ${len}` : ''})`),
+  left: (col: TCol | SQLExpr<string>, n: number): SQLExpr<string> =>
+    sqlExpr(`LEFT(${resolveArg(col, quoteFn)}, ${n})`),
+  right: (col: TCol | SQLExpr<string>, n: number): SQLExpr<string> =>
+    sqlExpr(`RIGHT(${resolveArg(col, quoteFn)}, ${n})`),
+  repeat: (col: TCol | SQLExpr<string>, n: number): SQLExpr<string> =>
+    sqlExpr(`REPEAT(${resolveArg(col, quoteFn)}, ${n})`),
+  reverse: (col: TCol | SQLExpr<string>): SQLExpr<string> =>
+    sqlExpr(`REVERSE(${resolveArg(col, quoteFn)})`),
+  lpad: (col: TCol | SQLExpr<string>, len: number, pad: string): SQLExpr<string> =>
+    sqlExpr(`LPAD(${resolveArg(col, quoteFn)}, ${len}, '${pad.replace(/'/g, "''")}')`),
+  rpad: (col: TCol | SQLExpr<string>, len: number, pad: string): SQLExpr<string> =>
+    sqlExpr(`RPAD(${resolveArg(col, quoteFn)}, ${len}, '${pad.replace(/'/g, "''")}')`),
+  locate: (substr: string, col: TCol | SQLExpr<string>): SQLExpr<number> =>
+    sqlExpr(`LOCATE('${esc(substr)}', ${resolveArg(col, quoteFn)})`),
+  space: (n: number): SQLExpr<string> =>
+    sqlExpr(`SPACE(${n})`),
 });
 
 export type DialectFns<TCol extends string = string> = ReturnType<typeof mysqlContextFns<TCol>>;

--- a/packages/prisma-ts-select/src/dialects/postgresql.ts
+++ b/packages/prisma-ts-select/src/dialects/postgresql.ts
@@ -21,6 +21,32 @@ export const postgresqlContextFns = <TCol extends string = string>(quoteFn: (ref
   bitOr:         (col: TCol): SQLExpr<number> => sqlExpr(`BIT_OR(${quoteFn(col)})`),
   jsonObjectAgg: (key: TCol, val: TCol): SQLExpr<JSONValue> =>
     sqlExpr(`JSON_OBJECT_AGG(${quoteFn(key)}, ${quoteFn(val)})`),
+  concat: (...args: Array<TCol | SQLExpr<string>>): SQLExpr<string> =>
+    sqlExpr(`CONCAT(${args.map(a => resolveArg(a, quoteFn)).join(', ')})`),
+  substring: (col: TCol | SQLExpr<string>, start: number, len?: number): SQLExpr<string> =>
+    sqlExpr(`SUBSTRING(${resolveArg(col, quoteFn)}, ${start}${len !== undefined ? `, ${len}` : ''})`),
+  left: (col: TCol | SQLExpr<string>, n: number): SQLExpr<string> =>
+    sqlExpr(`LEFT(${resolveArg(col, quoteFn)}, ${n})`),
+  right: (col: TCol | SQLExpr<string>, n: number): SQLExpr<string> =>
+    sqlExpr(`RIGHT(${resolveArg(col, quoteFn)}, ${n})`),
+  repeat: (col: TCol | SQLExpr<string>, n: number): SQLExpr<string> =>
+    sqlExpr(`REPEAT(${resolveArg(col, quoteFn)}, ${n})`),
+  reverse: (col: TCol | SQLExpr<string>): SQLExpr<string> =>
+    sqlExpr(`REVERSE(${resolveArg(col, quoteFn)})`),
+  lpad: (col: TCol | SQLExpr<string>, len: number, pad: string): SQLExpr<string> =>
+    sqlExpr(`LPAD(${resolveArg(col, quoteFn)}, ${len}, '${esc(pad)}')`),
+  rpad: (col: TCol | SQLExpr<string>, len: number, pad: string): SQLExpr<string> =>
+    sqlExpr(`RPAD(${resolveArg(col, quoteFn)}, ${len}, '${esc(pad)}')`),
+  initcap: (col: TCol | SQLExpr<string>): SQLExpr<string> =>
+    sqlExpr(`INITCAP(${resolveArg(col, quoteFn)})`),
+  strpos: (col: TCol | SQLExpr<string>, substr: string): SQLExpr<number> =>
+    sqlExpr(`STRPOS(${resolveArg(col, quoteFn)}, '${esc(substr)}')`),
+  splitPart: (col: TCol | SQLExpr<string>, delimiter: string, field: number): SQLExpr<string> =>
+    sqlExpr(`SPLIT_PART(${resolveArg(col, quoteFn)}, '${esc(delimiter)}', ${field})`),
+  btrim: (col: TCol | SQLExpr<string>, chars?: string): SQLExpr<string> =>
+    sqlExpr(`BTRIM(${resolveArg(col, quoteFn)}${chars !== undefined ? `, '${esc(chars)}'` : ''})`),
+  md5: (col: TCol | SQLExpr<string>): SQLExpr<string> =>
+    sqlExpr(`MD5(${resolveArg(col, quoteFn)})`),
 });
 
 export type DialectFns<TCol extends string = string> = ReturnType<typeof postgresqlContextFns<TCol>>;

--- a/packages/prisma-ts-select/src/dialects/sqlite.ts
+++ b/packages/prisma-ts-select/src/dialects/sqlite.ts
@@ -7,6 +7,18 @@ export const sqliteContextFns = <TCol extends string = string>(quoteFn: (ref: st
   groupConcat: (col: TCol, sep?: string): SQLExpr<string> =>
     sqlExpr(`GROUP_CONCAT(${quoteFn(col)}${sep !== undefined ? `, '${sep.replace(/'/g, "''")}'` : ''})`),
   total: (col: TCol): SQLExpr<number> => sqlExpr(`TOTAL(${quoteFn(col)})`),
+  concat: (...args: Array<TCol | SQLExpr<string>>): SQLExpr<string> =>
+    sqlExpr(args.map(a => resolveArg(a, quoteFn)).join(' || ')),
+  substr: (col: TCol | SQLExpr<string>, start: number, len?: number): SQLExpr<string> =>
+    sqlExpr(`SUBSTR(${resolveArg(col, quoteFn)}, ${start}${len !== undefined ? `, ${len}` : ''})`),
+  instr: (col: TCol | SQLExpr<string>, substr: string): SQLExpr<number> =>
+    sqlExpr(`INSTR(${resolveArg(col, quoteFn)}, '${substr.replace(/'/g, "''")}')`),
+  char: (...codes: number[]): SQLExpr<string> =>
+    sqlExpr(`CHAR(${codes.join(', ')})`),
+  hex: (col: TCol | SQLExpr<string>): SQLExpr<string> =>
+    sqlExpr(`HEX(${resolveArg(col, quoteFn)})`),
+  unicode: (col: TCol | SQLExpr<string>): SQLExpr<number> =>
+    sqlExpr(`UNICODE(${resolveArg(col, quoteFn)})`),
 });
 
 export type DialectFns<TCol extends string = string> = ReturnType<typeof sqliteContextFns<TCol>>;

--- a/packages/prisma-ts-select/src/extend.ts
+++ b/packages/prisma-ts-select/src/extend.ts
@@ -2221,6 +2221,13 @@ type BaseSelectFnContext<_TSources extends TArrSources, _TFields extends TFields
   countDistinct: <TCol extends GetOtherColumns<_TSources>>(col: TCol) => SQLExpr<number>;
   min: <TTable extends string, TCol extends string & keyof _TFields[TTable]>(col: `${TTable}.${TCol}`) => SQLExpr<_TFields[TTable][TCol]>;
   max: <TTable extends string, TCol extends string & keyof _TFields[TTable]>(col: `${TTable}.${TCol}`) => SQLExpr<_TFields[TTable][TCol]>;
+  replace: <TCol extends GetOtherColumns<_TSources>>(col: TCol | SQLExpr<string>, from: string, to: string) => SQLExpr<string>;
+  length: <TCol extends GetOtherColumns<_TSources>>(col: TCol | SQLExpr<string>) => SQLExpr<number>;
+  upper: <TCol extends GetOtherColumns<_TSources>>(col: TCol | SQLExpr<string>) => SQLExpr<string>;
+  lower: <TCol extends GetOtherColumns<_TSources>>(col: TCol | SQLExpr<string>) => SQLExpr<string>;
+  trim: <TCol extends GetOtherColumns<_TSources>>(col: TCol | SQLExpr<string>) => SQLExpr<string>;
+  ltrim: <TCol extends GetOtherColumns<_TSources>>(col: TCol | SQLExpr<string>) => SQLExpr<string>;
+  rtrim: <TCol extends GetOtherColumns<_TSources>>(col: TCol | SQLExpr<string>) => SQLExpr<string>;
 };
 
 /** Replaced by generator to inject dialect-specific fns via intersection. */
@@ -2238,6 +2245,13 @@ function buildContext<TSources extends TArrSources, TFields extends TFieldsType>
     countDistinct: (col) => sqlExpr(`COUNT(DISTINCT ${quoteFn(col)})`),
     min:           (col) => sqlExpr(`MIN(${resolveArg(col, quoteFn)})`),
     max:           (col) => sqlExpr(`MAX(${resolveArg(col, quoteFn)})`),
+    replace:       (col, from, to) => sqlExpr(`REPLACE(${resolveArg(col, quoteFn)}, '${from.replace(/'/g, "''")}', '${to.replace(/'/g, "''")}')`),
+    length:        (col) => sqlExpr(`LENGTH(${resolveArg(col, quoteFn)})`),
+    upper:         (col) => sqlExpr(`UPPER(${resolveArg(col, quoteFn)})`),
+    lower:         (col) => sqlExpr(`LOWER(${resolveArg(col, quoteFn)})`),
+    trim:          (col) => sqlExpr(`TRIM(${resolveArg(col, quoteFn)})`),
+    ltrim:         (col) => sqlExpr(`LTRIM(${resolveArg(col, quoteFn)})`),
+    rtrim:         (col) => sqlExpr(`RTRIM(${resolveArg(col, quoteFn)})`),
     ...dialectContextFns(quoteFn),
   } as SelectFnContext<TSources, TFields>;
 }

--- a/shared-tests/core/select-fn-string.spec.ts
+++ b/shared-tests/core/select-fn-string.spec.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Equal, Expect } from "../utils.ts";
+import { typeCheck } from "../utils.ts";
+import { expectSQL } from "../test-utils.ts";
+import { prisma } from '#client';
+import { dialect } from '#dialect';
+
+describe("select() string fn context", () => {
+
+    describe("upper(col)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ upper }) => upper("User.name"), "uname");
+        }
+
+        it("should match SQL", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT UPPER(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("uname", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ uname: string }>>>);
+        });
+
+        it("should return uppercase names", async () => {
+            const result = await createQuery().run();
+            const names = result.map(r => r.uname).filter(n => n !== null).sort();
+            assert.deepEqual(names, ["JOHN DOE", "JOHN SMITH", null].filter(n => n !== null).sort());
+        });
+    });
+
+    describe("lower(col)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ lower }) => lower("User.name"), "lname");
+        }
+
+        it("should match SQL", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT LOWER(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("lname", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ lname: string }>>>);
+        });
+
+        it("should return lowercase names", async () => {
+            const result = await createQuery().run();
+            const names = result.map(r => r.lname).filter((n): n is string => n !== null).sort();
+            assert.deepEqual(names, ["john doe", "john smith"]);
+        });
+    });
+
+    describe("length(col)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ length }) => length("User.email"), "elen");
+        }
+
+        it("should match SQL", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT LENGTH(${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("elen", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: number", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ elen: number }>>>);
+        });
+
+        it("should return correct lengths", async () => {
+            const result = await createQuery().run();
+            const lengths = result.map(r => Number(r.elen)).sort((a, b) => a - b);
+            // johndoe@example.com = 19, smith@example.com = 17, alice@example.com = 17
+            assert.deepEqual(lengths, [17, 17, 19]);
+        });
+    });
+
+    describe("trim(col)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ trim }) => trim("User.email"), "email");
+        }
+
+        it("should match SQL", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT TRIM(${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("email", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ email: string }>>>);
+        });
+    });
+
+    describe("ltrim(col)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ ltrim }) => ltrim("User.email"), "email");
+        }
+
+        it("should match SQL", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT LTRIM(${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("email", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ email: string }>>>);
+        });
+    });
+
+    describe("rtrim(col)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ rtrim }) => rtrim("User.email"), "email");
+        }
+
+        it("should match SQL", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT RTRIM(${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("email", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ email: string }>>>);
+        });
+    });
+
+    describe("replace(col, from, to)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ replace }) => replace("User.email", "@example.com", ""), "handle");
+        }
+
+        it("should match SQL", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT REPLACE(${dialect.quoteQualifiedColumn("User.email")}, '@example.com', '') AS ${dialect.quote("handle", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ handle: string }>>>);
+        });
+
+        it("should replace substring", async () => {
+            const result = await createQuery().run();
+            const handles = result.map(r => r.handle).sort();
+            assert.deepEqual(handles, ["alice", "johndoe", "smith"]);
+        });
+
+        it("should escape single quotes in from/to", () => {
+            const sql = prisma.$from("User")
+                .select(({ replace }) => replace("User.name", "it's", "its"), "fixed")
+                .getSQL();
+            expectSQL(sql,
+                `SELECT REPLACE(${dialect.quoteQualifiedColumn("User.name")}, 'it''s', 'its') AS ${dialect.quote("fixed", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+    describe("chaining: upper(lower(col))", () => {
+        it("should accept SQLExpr as input", () => {
+            const sql = prisma.$from("User")
+                .select(({ upper, lower }) => upper(lower("User.name")), "result")
+                .getSQL();
+            expectSQL(sql,
+                `SELECT UPPER(LOWER(${dialect.quoteQualifiedColumn("User.name")})) AS ${dialect.quote("result", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+    describe("composition — lit + column", () => {
+        it("upper(lit) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ upper, lit }) => upper(lit("hello")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT UPPER('hello') AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("trim(lit) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ trim, lit }) => trim(lit("  hello  ")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT TRIM('  hello  ') AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("length(lit) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ length, lit }) => length(lit("hello")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT LENGTH('hello') AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("length(upper(col)) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ length, upper }) => length(upper("User.name")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT LENGTH(UPPER(${dialect.quoteQualifiedColumn("User.name")})) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("ltrim(rtrim(col)) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ ltrim, rtrim }) => ltrim(rtrim("User.name")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT LTRIM(RTRIM(${dialect.quoteQualifiedColumn("User.name")})) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("trim(replace(col)) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ trim, replace }) => trim(replace("User.email", "johndoe@", "  johndoe@  ")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT TRIM(REPLACE(${dialect.quoteQualifiedColumn("User.email")}, 'johndoe@', '  johndoe@  ')) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("length(upper(replace(col))) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ length, upper, replace }) => length(upper(replace("User.name", "John", "Jon"))), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT LENGTH(UPPER(REPLACE(${dialect.quoteQualifiedColumn("User.name")}, 'John', 'Jon'))) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+});

--- a/shared-tests/dialect/mysql/select-fn-string.spec.ts
+++ b/shared-tests/dialect/mysql/select-fn-string.spec.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Equal, Expect } from "../../utils.ts";
+import { typeCheck } from "../../utils.ts";
+import { expectSQL } from "../../test-utils.ts";
+import { prisma } from '#client';
+import { dialect } from '#dialect';
+
+describe("MySQL string dialect fns", () => {
+
+    describe("concat(a, b)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ concat }) => concat("User.name", "User.email"), "full");
+        }
+
+        it("should use CONCAT()", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT CONCAT(${dialect.quoteQualifiedColumn("User.name")}, ${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("full", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ full: string }>>>);
+        });
+
+        it("should run and concatenate values", async () => {
+            const result = await createQuery().run();
+            const nonNull = result.filter(r => r.full !== null && r.full !== undefined);
+            assert.ok(nonNull.length >= 2);
+        });
+    });
+
+    describe("concat(a, b, c) — variadic", () => {
+        it("should join with CONCAT for 3 args", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, lower }) => concat("User.name", lower("User.email"), "User.email"), "full")
+                .getSQL();
+            expectSQL(sql,
+                `SELECT CONCAT(${dialect.quoteQualifiedColumn("User.name")}, LOWER(${dialect.quoteQualifiedColumn("User.email")}), ${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("full", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+    describe("substring(col, start)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ substring }) => substring("User.email", 1), "s");
+        }
+
+        it("should match SQL without len", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT SUBSTRING(${dialect.quoteQualifiedColumn("User.email")}, 1) AS ${dialect.quote("s", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ s: string }>>>);
+        });
+    });
+
+    describe("substring(col, start, len)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ substring }) => substring("User.email", 1, 5), "s");
+        }
+
+        it("should match SQL with len", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT SUBSTRING(${dialect.quoteQualifiedColumn("User.email")}, 1, 5) AS ${dialect.quote("s", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("should return first 5 chars", async () => {
+            const result = await createQuery().run();
+            const values = result.map(r => r.s).sort();
+            assert.deepEqual(values, ["alice", "johnd", "smith"]);
+        });
+    });
+
+    describe("composition — lit + column", () => {
+        it("concat(lit, col, lit) — uses CONCAT()", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, lit }) => concat(lit(" "), "User.name", lit(" ")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT CONCAT(' ', ${dialect.quoteQualifiedColumn("User.name")}, ' ') AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("ltrim(rtrim(concat(lit, col, lit))) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ ltrim, rtrim, concat, lit }) => ltrim(rtrim(concat(lit("  "), "User.name", lit("  ")))), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT LTRIM(RTRIM(CONCAT('  ', ${dialect.quoteQualifiedColumn("User.name")}, '  '))) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("concat(upper(col), lit) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, upper, lit }) => concat(upper("User.name"), lit("!")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT CONCAT(UPPER(${dialect.quoteQualifiedColumn("User.name")}), '!') AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("substring(upper(col), 1, 4) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ substring, upper }) => substring(upper("User.name"), 1, 4), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT SUBSTRING(UPPER(${dialect.quoteQualifiedColumn("User.name")}), 1, 4) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+
+    describe("left(col, n)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ left }) => left("User.email", 5), "prefix")
+                .getSQL();
+            expectSQL(sql, `SELECT LEFT(${dialect.quoteQualifiedColumn("User.email")}, 5) AS ${dialect.quote("prefix", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ left }) => left("User.email", 5), "prefix")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ prefix: string }>>>);
+        });
+
+        it("should return first 5 chars", async () => {
+            const result = await prisma.$from("User")
+                .select(({ left }) => left("User.email", 5), "prefix")
+                .run();
+            const vals = result.map(r => r.prefix).sort();
+            assert.deepEqual(vals, ["alice", "johnd", "smith"]);
+        });
+    });
+
+    describe("right(col, n)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ right }) => right("User.email", 11), "domain")
+                .getSQL();
+            expectSQL(sql, `SELECT RIGHT(${dialect.quoteQualifiedColumn("User.email")}, 11) AS ${dialect.quote("domain", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ right }) => right("User.email", 11), "domain")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ domain: string }>>>);
+        });
+
+        it("should return last 11 chars (example.com)", async () => {
+            const result = await prisma.$from("User")
+                .select(({ right }) => right("User.email", 11), "domain")
+                .run();
+            assert.ok(result.every(r => r.domain === "example.com"));
+        });
+    });
+
+    describe("repeat(col, n)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ repeat }) => repeat("User.name", 2), "doubled")
+                .getSQL();
+            expectSQL(sql, `SELECT REPEAT(${dialect.quoteQualifiedColumn("User.name")}, 2) AS ${dialect.quote("doubled", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ repeat }) => repeat("User.name", 2), "doubled")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ doubled: string }>>>);
+        });
+    });
+
+    describe("reverse(col)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ reverse }) => reverse("User.name"), "rev")
+                .getSQL();
+            expectSQL(sql, `SELECT REVERSE(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("rev", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ reverse }) => reverse("User.name"), "rev")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ rev: string }>>>);
+        });
+    });
+
+    describe("lpad(col, len, pad)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ lpad }) => lpad("User.name", 10, "*"), "padded")
+                .getSQL();
+            expectSQL(sql, `SELECT LPAD(${dialect.quoteQualifiedColumn("User.name")}, 10, '*') AS ${dialect.quote("padded", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ lpad }) => lpad("User.name", 10, "*"), "padded")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ padded: string }>>>);
+        });
+    });
+
+    describe("rpad(col, len, pad)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ rpad }) => rpad("User.name", 10, "-"), "padded")
+                .getSQL();
+            expectSQL(sql, `SELECT RPAD(${dialect.quoteQualifiedColumn("User.name")}, 10, '-') AS ${dialect.quote("padded", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ rpad }) => rpad("User.name", 10, "-"), "padded")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ padded: string }>>>);
+        });
+    });
+
+    describe("locate(substr, col)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ locate }) => locate("@", "User.email"), "pos")
+                .getSQL();
+            expectSQL(sql, `SELECT LOCATE('@', ${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("pos", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: number", async () => {
+            const result = await prisma.$from("User")
+                .select(({ locate }) => locate("@", "User.email"), "pos")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ pos: number }>>>);
+        });
+
+        it("should return position of @", async () => {
+            const result = await prisma.$from("User")
+                .select(({ locate }) => locate("@", "User.email"), "pos")
+                .run();
+            const positions = result.map(r => Number(r.pos)).sort((a, b) => a - b);
+            assert.deepEqual(positions, [6, 6, 8]);
+        });
+    });
+
+    describe("space(n)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ space }) => space(3), "s")
+                .getSQL();
+            expectSQL(sql, `SELECT SPACE(3) AS ${dialect.quote("s", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ space }) => space(3), "s")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ s: string }>>>);
+        });
+
+        it("should return 3 spaces", async () => {
+            const result = await prisma.$from("User")
+                .select(({ space }) => space(3), "s")
+                .run();
+            assert.ok(result.every(r => r.s === "   "));
+        });
+    });
+
+});

--- a/shared-tests/dialect/pg/select-fn-string.spec.ts
+++ b/shared-tests/dialect/pg/select-fn-string.spec.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Equal, Expect } from "../../utils.ts";
+import { typeCheck } from "../../utils.ts";
+import { expectSQL } from "../../test-utils.ts";
+import { prisma } from '#client';
+import { dialect } from '#dialect';
+
+describe("PostgreSQL string dialect fns", () => {
+
+    describe("concat(a, b)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ concat }) => concat("User.name", "User.email"), "full");
+        }
+
+        it("should use CONCAT()", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT CONCAT(${dialect.quoteQualifiedColumn("User.name")}, ${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("full", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ full: string }>>>);
+        });
+
+        it("should run and concatenate values", async () => {
+            const result = await createQuery().run();
+            const nonNull = result.filter(r => r.full !== null && r.full !== undefined);
+            assert.ok(nonNull.length >= 2);
+        });
+    });
+
+    describe("concat(a, b, c) — variadic", () => {
+        it("should join with CONCAT for 3 args", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, lower }) => concat("User.name", lower("User.email"), "User.email"), "full")
+                .getSQL();
+            expectSQL(sql,
+                `SELECT CONCAT(${dialect.quoteQualifiedColumn("User.name")}, LOWER(${dialect.quoteQualifiedColumn("User.email")}), ${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("full", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+    describe("substring(col, start)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ substring }) => substring("User.email", 1), "s");
+        }
+
+        it("should match SQL without len", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT SUBSTRING(${dialect.quoteQualifiedColumn("User.email")}, 1) AS ${dialect.quote("s", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ s: string }>>>);
+        });
+    });
+
+    describe("substring(col, start, len)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ substring }) => substring("User.email", 1, 5), "s");
+        }
+
+        it("should match SQL with len", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT SUBSTRING(${dialect.quoteQualifiedColumn("User.email")}, 1, 5) AS ${dialect.quote("s", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("should return first 5 chars", async () => {
+            const result = await createQuery().run();
+            const values = result.map(r => r.s).sort();
+            assert.deepEqual(values, ["alice", "johnd", "smith"]);
+        });
+    });
+
+    describe("composition — lit + column", () => {
+        it("concat(lit, col, lit) — uses CONCAT()", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, lit }) => concat(lit(" "), "User.name", lit(" ")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT CONCAT(' ', ${dialect.quoteQualifiedColumn("User.name")}, ' ') AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("ltrim(rtrim(concat(lit, col, lit))) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ ltrim, rtrim, concat, lit }) => ltrim(rtrim(concat(lit("  "), "User.name", lit("  ")))), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT LTRIM(RTRIM(CONCAT('  ', ${dialect.quoteQualifiedColumn("User.name")}, '  '))) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("concat(upper(col), lit) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, upper, lit }) => concat(upper("User.name"), lit("!")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT CONCAT(UPPER(${dialect.quoteQualifiedColumn("User.name")}), '!') AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("substring(upper(col), 1, 4) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ substring, upper }) => substring(upper("User.name"), 1, 4), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT SUBSTRING(UPPER(${dialect.quoteQualifiedColumn("User.name")}), 1, 4) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+
+    describe("left(col, n)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ left }) => left("User.email", 5), "prefix")
+                .getSQL();
+            expectSQL(sql, `SELECT LEFT(${dialect.quoteQualifiedColumn("User.email")}, 5) AS ${dialect.quote("prefix", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ left }) => left("User.email", 5), "prefix")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ prefix: string }>>>);
+        });
+    });
+
+    describe("right(col, n)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ right }) => right("User.email", 11), "domain")
+                .getSQL();
+            expectSQL(sql, `SELECT RIGHT(${dialect.quoteQualifiedColumn("User.email")}, 11) AS ${dialect.quote("domain", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ right }) => right("User.email", 11), "domain")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ domain: string }>>>);
+        });
+    });
+
+    describe("repeat(col, n)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ repeat }) => repeat("User.name", 2), "doubled")
+                .getSQL();
+            expectSQL(sql, `SELECT REPEAT(${dialect.quoteQualifiedColumn("User.name")}, 2) AS ${dialect.quote("doubled", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ repeat }) => repeat("User.name", 2), "doubled")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ doubled: string }>>>);
+        });
+    });
+
+    describe("reverse(col)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ reverse }) => reverse("User.name"), "rev")
+                .getSQL();
+            expectSQL(sql, `SELECT REVERSE(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("rev", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ reverse }) => reverse("User.name"), "rev")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ rev: string }>>>);
+        });
+    });
+
+    describe("lpad(col, len, pad)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ lpad }) => lpad("User.name", 10, "*"), "padded")
+                .getSQL();
+            expectSQL(sql, `SELECT LPAD(${dialect.quoteQualifiedColumn("User.name")}, 10, '*') AS ${dialect.quote("padded", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ lpad }) => lpad("User.name", 10, "*"), "padded")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ padded: string }>>>);
+        });
+    });
+
+    describe("rpad(col, len, pad)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ rpad }) => rpad("User.name", 10, "-"), "padded")
+                .getSQL();
+            expectSQL(sql, `SELECT RPAD(${dialect.quoteQualifiedColumn("User.name")}, 10, '-') AS ${dialect.quote("padded", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ rpad }) => rpad("User.name", 10, "-"), "padded")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ padded: string }>>>);
+        });
+    });
+
+    describe("initcap(col)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ initcap }) => initcap("User.name"), "titled")
+                .getSQL();
+            expectSQL(sql, `SELECT INITCAP(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("titled", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ initcap }) => initcap("User.name"), "titled")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ titled: string }>>>);
+        });
+    });
+
+    describe("strpos(col, substr)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ strpos }) => strpos("User.email", "@"), "pos")
+                .getSQL();
+            expectSQL(sql, `SELECT STRPOS(${dialect.quoteQualifiedColumn("User.email")}, '@') AS ${dialect.quote("pos", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: number", async () => {
+            const result = await prisma.$from("User")
+                .select(({ strpos }) => strpos("User.email", "@"), "pos")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ pos: number }>>>);
+        });
+    });
+
+    describe("splitPart(col, delimiter, field)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ splitPart }) => splitPart("User.email", "@", 1), "handle")
+                .getSQL();
+            expectSQL(sql, `SELECT SPLIT_PART(${dialect.quoteQualifiedColumn("User.email")}, '@', 1) AS ${dialect.quote("handle", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ splitPart }) => splitPart("User.email", "@", 1), "handle")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ handle: string }>>>);
+        });
+    });
+
+    describe("btrim(col, chars?)", () => {
+        it("should match SQL — no chars", () => {
+            const sql = prisma.$from("User")
+                .select(({ btrim }) => btrim("User.name"), "t")
+                .getSQL();
+            expectSQL(sql, `SELECT BTRIM(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("t", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("should match SQL — with chars", () => {
+            const sql = prisma.$from("User")
+                .select(({ btrim }) => btrim("User.name", "J"), "t")
+                .getSQL();
+            expectSQL(sql, `SELECT BTRIM(${dialect.quoteQualifiedColumn("User.name")}, 'J') AS ${dialect.quote("t", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ btrim }) => btrim("User.name"), "t")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ t: string }>>>);
+        });
+    });
+
+    describe("md5(col)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ md5 }) => md5("User.email"), "hash")
+                .getSQL();
+            expectSQL(sql, `SELECT MD5(${dialect.quoteQualifiedColumn("User.email")}) AS ${dialect.quote("hash", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ md5 }) => md5("User.email"), "hash")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ hash: string }>>>);
+        });
+    });
+
+});

--- a/shared-tests/dialect/sqlite/select-fn-string.spec.ts
+++ b/shared-tests/dialect/sqlite/select-fn-string.spec.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Equal, Expect } from "../../utils.ts";
+import { typeCheck } from "../../utils.ts";
+import { expectSQL } from "../../test-utils.ts";
+import { prisma } from '#client';
+import { dialect } from '#dialect';
+
+describe("SQLite string dialect fns", () => {
+
+    describe("concat(a, b)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ concat }) => concat("User.name", "User.email"), "full");
+        }
+
+        it("should use || operator", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT ${dialect.quoteQualifiedColumn("User.name")} || ${dialect.quoteQualifiedColumn("User.email")} AS ${dialect.quote("full", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ full: string }>>>);
+        });
+
+        it("should run and concatenate values", async () => {
+            const result = await createQuery().run();
+            // Only check non-null rows (User 3 has null name)
+            const nonNull = result.filter(r => r.full !== null && r.full !== undefined);
+            assert.ok(nonNull.length >= 2);
+        });
+    });
+
+    describe("concat(a, b, c) — variadic", () => {
+        it("should join with || for 3 args", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, lower }) => concat("User.name", lower("User.email"), "User.email"), "full")
+                .getSQL();
+            expectSQL(sql,
+                `SELECT ${dialect.quoteQualifiedColumn("User.name")} || LOWER(${dialect.quoteQualifiedColumn("User.email")}) || ${dialect.quoteQualifiedColumn("User.email")} AS ${dialect.quote("full", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+    describe("substr(col, start)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ substr }) => substr("User.email", 1), "s");
+        }
+
+        it("should match SQL without len", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT SUBSTR(${dialect.quoteQualifiedColumn("User.email")}, 1) AS ${dialect.quote("s", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await createQuery().run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ s: string }>>>);
+        });
+    });
+
+    describe("substr(col, start, len)", () => {
+        function createQuery() {
+            return prisma.$from("User").select(({ substr }) => substr("User.email", 1, 5), "s");
+        }
+
+        it("should match SQL with len", () => {
+            expectSQL(createQuery().getSQL(),
+                `SELECT SUBSTR(${dialect.quoteQualifiedColumn("User.email")}, 1, 5) AS ${dialect.quote("s", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("should return first 5 chars", async () => {
+            const result = await createQuery().run();
+            const values = result.map(r => r.s).sort();
+            assert.deepEqual(values, ["alice", "johnd", "smith"]);
+        });
+    });
+
+    describe("composition — lit + column", () => {
+        it("concat(lit, col, lit) — uses || operator", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, lit }) => concat(lit(" "), "User.name", lit(" ")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT ' ' || ${dialect.quoteQualifiedColumn("User.name")} || ' ' AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("ltrim(rtrim(concat(lit, col, lit))) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ ltrim, rtrim, concat, lit }) => ltrim(rtrim(concat(lit("  "), "User.name", lit("  ")))), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT LTRIM(RTRIM('  ' || ${dialect.quoteQualifiedColumn("User.name")} || '  ')) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("concat(upper(col), lit) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ concat, upper, lit }) => concat(upper("User.name"), lit("!")), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT UPPER(${dialect.quoteQualifiedColumn("User.name")}) || '!' AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("substr(upper(col), 1, 4) — SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ substr, upper }) => substr(upper("User.name"), 1, 4), "r")
+                .getSQL();
+            expectSQL(sql, `SELECT SUBSTR(UPPER(${dialect.quoteQualifiedColumn("User.name")}), 1, 4) AS ${dialect.quote("r", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("ltrim(rtrim(concat)) — runtime strips whitespace", async () => {
+            const result = await prisma.$from("User")
+                .select(({ ltrim, rtrim, concat, lit }) => ltrim(rtrim(concat(lit("  "), "User.name", lit("  ")))), "r")
+                .run();
+            const names = result.map(r => r.r).filter((n): n is string => n !== null);
+            for (const name of names) {
+                assert.ok(!name.startsWith(" "), `Expected no leading space, got: "${name}"`);
+                assert.ok(!name.endsWith(" "), `Expected no trailing space, got: "${name}"`);
+            }
+        });
+    });
+
+
+    describe("instr(col, substr)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ instr }) => instr("User.email", "@"), "pos")
+                .getSQL();
+            expectSQL(sql, `SELECT INSTR(${dialect.quoteQualifiedColumn("User.email")}, '@') AS ${dialect.quote("pos", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: number", async () => {
+            const result = await prisma.$from("User")
+                .select(({ instr }) => instr("User.email", "@"), "pos")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ pos: number }>>>);
+        });
+
+        it("should return position of @", async () => {
+            const result = await prisma.$from("User")
+                .select(({ instr }) => instr("User.email", "@"), "pos")
+                .run();
+            // johndoe@example.com → 8, smith@example.com → 6, alice@example.com → 6
+            const positions = result.map(r => Number(r.pos)).sort((a, b) => a - b);
+            assert.deepEqual(positions, [6, 6, 8]);
+        });
+
+        it("should escape single quotes", () => {
+            const sql = prisma.$from("User")
+                .select(({ instr }) => instr("User.name", "it's"), "pos")
+                .getSQL();
+            expectSQL(sql, `SELECT INSTR(${dialect.quoteQualifiedColumn("User.name")}, 'it''s') AS ${dialect.quote("pos", true)} FROM ${dialect.quote("User")};`);
+        });
+    });
+
+    describe("char(...codes)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ char }) => char(65, 66, 67), "abc")
+                .getSQL();
+            expectSQL(sql, `SELECT CHAR(65, 66, 67) AS ${dialect.quote("abc", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ char }) => char(65, 66, 67), "abc")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ abc: string }>>>);
+        });
+
+        it("should return 'ABC'", async () => {
+            const result = await prisma.$from("User")
+                .select(({ char }) => char(65, 66, 67), "abc")
+                .run();
+            assert.ok(result.every(r => r.abc === "ABC"));
+        });
+    });
+
+    describe("hex(col)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ hex }) => hex("User.name"), "h")
+                .getSQL();
+            expectSQL(sql, `SELECT HEX(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("h", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ hex }) => hex("User.name"), "h")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ h: string }>>>);
+        });
+
+        it("should return hex string", async () => {
+            const result = await prisma.$from("User")
+                .select(({ hex }) => hex("User.name"), "h")
+                .run();
+            const hexVals = result.map(r => r.h).filter((h): h is string => h !== null && h !== "");
+            // hex values should only contain valid hex chars
+            assert.ok(hexVals.every(h => /^[0-9A-Fa-f]+$/.test(h)));
+        });
+    });
+
+    describe("unicode(col)", () => {
+        it("should match SQL", () => {
+            const sql = prisma.$from("User")
+                .select(({ unicode }) => unicode("User.name"), "code")
+                .getSQL();
+            expectSQL(sql, `SELECT UNICODE(${dialect.quoteQualifiedColumn("User.name")}) AS ${dialect.quote("code", true)} FROM ${dialect.quote("User")};`);
+        });
+
+        it("type: number", async () => {
+            const result = await prisma.$from("User")
+                .select(({ unicode }) => unicode("User.name"), "code")
+                .run();
+            typeCheck({} as Expect<Equal<typeof result, Array<{ code: number }>>>);
+        });
+
+        it("should return unicode code point of first char", async () => {
+            const result = await prisma.$from("User")
+                .select(({ unicode }) => unicode("User.name"), "code")
+                .run();
+            // "John Doe" → J=74, "John Smith" → J=74, null user → null
+            // SQLite may return BigInt — convert for portable comparison
+            const codes = result.map(r => r.code).filter(c => c !== null).map(c => Number(c));
+            assert.ok(codes.every(c => Number.isInteger(c)));
+            // First char of both names is 'J' (74)
+            assert.ok(codes.includes(74));
+        });
+    });
+
+});

--- a/shared-tests/readme/select-fns.ts
+++ b/shared-tests/readme/select-fns.ts
@@ -143,6 +143,71 @@ prisma.$from("User")
     expectSQL(sql, `SELECT MAX(User.age) AS \`oldest\` FROM User;`);
   });
 
+  // ── upper() ─────────────────────────────────────────────────────────────
+
+  test("upper(col)", () => {
+    const sql =
+// #region upper
+prisma.$from("User")
+      .select(({ upper }) => upper("User.name"), "uname")
+      // #endregion upper
+.getSQL();
+
+    expectSQL(sql, `SELECT UPPER(User.name) AS \`uname\` FROM User;`);
+  });
+
+  // ── lower() ─────────────────────────────────────────────────────────────
+
+  test("lower(col)", () => {
+    const sql =
+// #region lower
+prisma.$from("User")
+      .select(({ lower }) => lower("User.name"), "lname")
+      // #endregion lower
+.getSQL();
+
+    expectSQL(sql, `SELECT LOWER(User.name) AS \`lname\` FROM User;`);
+  });
+
+  // ── length() ─────────────────────────────────────────────────────────────
+
+  test("length(col)", () => {
+    const sql =
+// #region length
+prisma.$from("User")
+      .select(({ length }) => length("User.email"), "elen")
+      // #endregion length
+.getSQL();
+
+    expectSQL(sql, `SELECT LENGTH(User.email) AS \`elen\` FROM User;`);
+  });
+
+  // ── trim() ─────────────────────────────────────────────────────────────
+
+  test("trim(col)", () => {
+    const sql =
+// #region trim
+prisma.$from("User")
+      .select(({ trim }) => trim("User.email"), "email")
+      // #endregion trim
+.getSQL();
+
+    expectSQL(sql, `SELECT TRIM(User.email) AS \`email\` FROM User;`);
+  });
+
+  // ── replace() ─────────────────────────────────────────────────────────────
+
+  test("replace(col, from, to)", () => {
+    const sql =
+// #region replace
+prisma.$from("User")
+      .select(({ replace }) => replace("User.email", "@example.com", ""), "handle")
+      // #endregion replace
+.getSQL();
+
+    expectSQL(sql, `SELECT REPLACE(User.email, '@example.com', '') AS \`handle\` FROM User;`);
+  });
+
   // ── mixed: count + group ─────────────────────────────────────────────────
 
   test("countAll + groupBy", () => {


### PR DESCRIPTION
This pull request introduces string manipulation functions compatible with SQLite, MySQL, and PostgreSQL database dialects. 

### Changes:
- Implemented support for a range of string manipulation functions across the three database dialects.
- Added comprehensive tests to ensure function accuracy and reliability.
- Updated documentation to include details on the usage of the new functions.

### Checklist:
- [ ] Tests are included for this change
- [ ] Documentation is updated as needed
- [ ] The build and tests are passing