### PR TITLE
feat: adding expanded where support

### DIFF
--- a/packages/prisma-ts-select/src/extend.ts
+++ b/packages/prisma-ts-select/src/extend.ts
@@ -227,24 +227,6 @@ type ValidSelect<Tables extends TArrSources> =
     | GetTableStar<Tables>;// | GetColsFromTable<Tables[number]>; // TODO
 
 /**
- * Extracts all available column names from base table and joined tables.
- * Returns column names from the base table (without prefix) and qualified column names
- * from all tables (with "Table.column" prefix).
- *
- * @template Tables - Array of table sources, first element is base table
- * @returns Union of column names: base table columns | "Table.column" for all tables
- *
- * @example
- * // For tables ["User", "Post"]
- * GetOtherColumns<["User", "Post"]>
- * // Returns: "id" | "name" | "User.id" | "User.name" | "Post.id" | "Post.title"
- */
-//@ts-expect-error using a never version
-type GetOtherColumns_old<Tables extends TArrSources> = Tables extends [infer T extends TTableSources, ...Array<TTableSources>]
-    ? GetColsBaseTable<T> | GetJoinCols<Tables[number]>
-    : never
-
-/**
  * Generates "Table.*" patterns for all tables in the query.
  * Handles both simple table names and table aliases.
  *
@@ -457,6 +439,10 @@ function processConditions(condition: BasicOpTypes, formatted = false): string {
         } else if (value === null) {
             return `${quotedField} IS NULL`;
         } else if (Array.isArray(value)) {
+            if (value.length > 0 && typeof value[0] === 'object' && value[0] !== null && 'op' in value[0]) {
+                const parts = (value as Array<{ op: string; value: SUPPORTED_TYPES }>).map(opObj => processConditions({ [field]: opObj } as BasicOpTypes, formatted));
+                return parts.length === 1 ? parts[0]! : "(" + parts.join(" OR ") + ")";
+            }
             const valuesList = value.map(v => (typeof v === 'string' ? `'${v}'` : v)).join(", ");
             return `${quotedField} IN (${valuesList})`;
         }  else {
@@ -703,36 +689,6 @@ class _fOrderBy<TSources extends TArrSources, TFields extends TFieldsType, TSele
     }
 }
 
-
-/*
-SELECT - the final data is returned.
-ORDER BY - the final data is sorted.
-LIMIT - the returned data is limited to row count.
-OFFSET -
-run
-*/
-//@ts-expect-error yeah old version for comp
-type MergeItemsOld<Field extends string,
-    TSources extends [TTables,...Array<TTables>],
-    TFields extends TFieldsType,
-    IncTName extends boolean = false,
-    TLTables = TSources[number]> =
-    Field extends "*"
-        ? Prettify<IterateTables<TSources, TFields, IncTName>>
-        : Field extends `${infer T}.*`
-            ? T extends keyof TFields
-                ? [TSources] extends [[T]]
-                    // Single table - no prefix
-                    ? TFields[T]
-                    // Multiple tables - with prefix
-                    : T extends string ? IterateTablesFromFields<T, TFields[T], true> : never
-                : never
-            //@ts-expect-error T not a string?
-            : Field extends `${infer T extends TLTables}.${infer F extends string}`
-                //@ts-expect-error F is part of T, but can't tell TS that
-                ? Pick<TFields[T], F>
-                //@-ts-expect-error Field is part of the from, but can't tell TS that.
-                : Pick<TFields[TSources[0]], Field>;
 
 /**
  * Transforms a field selection pattern into its corresponding TypeScript type structure.
@@ -1289,9 +1245,11 @@ type OptionalObject<K extends Record<PropertyKey, unknown>> = { [key in keyof K]
  */
 type COND_NUMERIC<key extends PropertyKey, keyType> =
     | OptionalRecord<key, keyType>
+    | OptionalRecord<key, Array<keyType>>
     | OptionalRecord<key, { op: 'IN' | 'NOT IN'; values: Array<keyType> }>
     | OptionalRecord<key, { op: 'BETWEEN'; values: [keyType, keyType] }>
-    | OptionalRecord<key, { op: '>' | '>=' | '<' | '<=' | '!=' | '='; value: keyType }>;
+    | OptionalRecord<key, { op: '>' | '>=' | '<' | '<=' | '!=' | '='; value: keyType }>
+    | OptionalRecord<key, Array<{ op: '>' | '>=' | '<' | '<=' | '!=' | '='; value: keyType }>>;
 
 /**
  * Defines all valid SQL condition patterns for string types.
@@ -1307,9 +1265,11 @@ type COND_NUMERIC<key extends PropertyKey, keyType> =
  */
 type COND_STRING<key extends PropertyKey> =
     | OptionalRecord<key, string>
+    | OptionalRecord<key, Array<string>>
     | OptionalRecord<key, { op: 'IN' | 'NOT IN'; values: Array<string> }>
     | OptionalRecord<key, { op: 'LIKE' | 'NOT LIKE'; value: string }>
-    | OptionalRecord<key, { op: '!='; value: string }>;
+    | OptionalRecord<key, { op: '!='; value: string }>
+    | OptionalRecord<key, Array<{ op: 'LIKE' | 'NOT LIKE' | '!=' | '='; value: string }>>;
 
 /**
  * Defines all valid SQL condition patterns for DateTime/Date types.
@@ -1326,9 +1286,11 @@ type COND_STRING<key extends PropertyKey> =
  */
 type COND_DATETIME<key extends PropertyKey, keyType> =
     | OptionalRecord<key, keyType>
+    | OptionalRecord<key, Array<keyType>>
     | OptionalRecord<key, { op: 'IN' | 'NOT IN'; values: Array<keyType> }>
     | OptionalRecord<key, { op: 'BETWEEN'; values: [keyType, keyType] }>
-    | OptionalRecord<key, { op: '>' | '>=' | '<' | '<=' | '!='; value: keyType }>;
+    | OptionalRecord<key, { op: '>' | '>=' | '<' | '<=' | '!='; value: keyType }>
+    | OptionalRecord<key, Array<{ op: '>' | '>=' | '<' | '<=' | '!='; value: keyType }>>;
 
 /**
  * Defines all valid SQL condition patterns for boolean types.
@@ -1393,11 +1355,13 @@ type SQLCondition<T> = Prettify<{
 
 type BasicOpTypes =
     | OptionalRecord<PropertyKey, SUPPORTED_TYPES>
+    | OptionalRecord<PropertyKey, Array<SUPPORTED_TYPES>>
     | OptionalRecord<PropertyKey, { op: 'IN' | 'NOT IN'; values: Array<SUPPORTED_TYPES> }>
     | OptionalRecord<PropertyKey, { op: 'BETWEEN'; values: [SUPPORTED_TYPES, SUPPORTED_TYPES] }>
     | OptionalRecord<PropertyKey, { op: 'LIKE' | 'NOT LIKE'; value: string }>
     | OptionalRecord<PropertyKey, { op: 'IS NULL' | 'IS NOT NULL' }>
-    | OptionalRecord<PropertyKey, { op: '>' | '>=' | '<' | '<=' | '!=' | '='; value: SUPPORTED_TYPES }>;
+    | OptionalRecord<PropertyKey, { op: '>' | '>=' | '<' | '<=' | '!=' | '='; value: SUPPORTED_TYPES }>
+    | OptionalRecord<PropertyKey, Array<{ op: string; value: SUPPORTED_TYPES }>>;
 
 /**
  * Transforms a table's fields into a record where keys are prefixed with the table name ("Table.field").

--- a/shared-tests/core/criteria.spec.ts
+++ b/shared-tests/core/criteria.spec.ts
@@ -232,6 +232,76 @@ describe("where", () => {
     });
 });
 
+describe("where array shorthand", () => {
+
+    describe("Stage 1: scalar array → IN", () => {
+
+        const q = () => prisma.$from("User").where({ "name": ["John Doe", "John Smith"] }).selectAll();
+
+        it("should match SQL", () => {
+            const cols = ["id", "email", "name", "age"].map(c => dialect.quote(c)).join(", ");
+            expectSQL(
+                q().getSQL(),
+                `SELECT ${cols} FROM ${dialect.quote("User")} WHERE ${dialect.quote("name")} IN ('John Doe', 'John Smith');`
+            );
+        });
+
+        it("should run and return matching users", async () => {
+            const result = await q().run();
+            assert.equal(result.length, 2);
+            assert.ok(result.some(u => u.name === "John Doe"));
+            assert.ok(result.some(u => u.name === "John Smith"));
+        });
+
+        it("type: numeric array compiles", () => {
+            prisma.$from("User").where({ "age": [25, 30] });
+        });
+
+        it("type: mixed array is error", () => {
+            prisma.$from("User").where({
+                //@ts-expect-error mixed string/number array not allowed for numeric field
+                "age": ["a", 25]
+            });
+        });
+
+    });
+
+    describe("Stage 2: op-object array → OR chain", () => {
+
+        const q = () => prisma.$from("User")
+            .where({ "name": [{ op: "LIKE", value: "John D%" }, { op: "LIKE", value: "John S%" }] })
+            .selectAll();
+
+        it("should match SQL", () => {
+            const cols = ["id", "email", "name", "age"].map(c => dialect.quote(c)).join(", ");
+            expectSQL(
+                q().getSQL(),
+                `SELECT ${cols} FROM ${dialect.quote("User")} WHERE (${dialect.quote("name")} LIKE 'John D%' OR ${dialect.quote("name")} LIKE 'John S%');`
+            );
+        });
+
+        it("should run and return both Johns", async () => {
+            const result = await q().run();
+            assert.equal(result.length, 2);
+            assert.ok(result.some(u => u.name === "John Doe"));
+            assert.ok(result.some(u => u.name === "John Smith"));
+        });
+
+        it("type: numeric op-array compiles", () => {
+            prisma.$from("User").where({ "age": [{ op: ">=", value: 18 }, { op: "<=", value: 65 }] });
+        });
+
+        it("type: IN op in array is error", () => {
+            prisma.$from("User").where({
+                //@ts-expect-error IN uses 'values', not valid in op-array
+                "name": [{ op: "IN", values: ["a"] }]
+            });
+        });
+
+    });
+
+});
+
 describe("having", () => {
 
     describe("HAVING with GROUP BY", () => {
@@ -379,7 +449,7 @@ describe("having", () => {
         });
 
         it("should allow select() after groupBy()", () => {
-            const query = prisma.$from("User")
+            prisma.$from("User")
                 .groupBy(["User.id"])
                 .select("User.id")
                 .select("User.name");
@@ -387,7 +457,7 @@ describe("having", () => {
         });
 
         it("should allow selectDistinct() after groupBy()", () => {
-            const query = prisma.$from("User")
+            prisma.$from("User")
                 .groupBy(["User.id"])
                 .selectDistinct();
             // Should compile without errors


### PR DESCRIPTION
Adding support for 
where({
property: [item1, item3]
})

becomes (property = item1 OR property = item2)