### PR TITLE
Extend CTE joins with `where` option

### DIFF
--- a/packages/prisma-ts-select/src/extend.ts
+++ b/packages/prisma-ts-select/src/extend.ts
@@ -2482,14 +2482,15 @@ class _fJoin<
 
     /**
      * CTE join overload — when table name is a known CTE.
-     * @note `joinWhere` (additional ON-clause filtering) is not supported for CTE joins.
-     * Use `.where()` after the join to filter CTE results instead.
      */
     join<const TName extends keyof TCTEs & string>(
         cteName: TName,
         local: keyof TCTEs[TName] & string,
         remote: GetJoinCols<TSources[number]>,
-        opts?: { joinType?: JoinType }
+        opts?: {
+            where?: WhereCriteriaMulti<[readonly ["__cte__", TName]], Record<TName, TCTEs[TName]>>,
+            joinType?: JoinType
+        }
     ): _fJoin<[...TSources, readonly ["__cte__", TName]], TFields & Record<TName, TCTEs[TName]>, TCTEs>
 
     // Overload 1: Object syntax

--- a/packages/prisma-ts-select/src/extend.ts
+++ b/packages/prisma-ts-select/src/extend.ts
@@ -2797,6 +2797,16 @@ joinUnsafeTypeEnforced<const Table extends TTables | `${TTables} ${string}`,
 
     // ── Named join methods ───────────────────────────────────────────────
 
+    /**
+     * CTE innerJoin — `where` appends conditions to the ON clause.
+     * Scoped to CTE fields only; use `join()` for cross-table conditions.
+     */
+    innerJoin<const TName extends keyof TCTEs & string>(
+        cteName: TName,
+        local: keyof TCTEs[TName] & string,
+        remote: GetJoinCols<TSources[number]>,
+        opts?: { where?: WhereCriteriaMulti<[readonly ["__cte__", TName]], Record<TName, TCTEs[TName]>> }
+    ): _fJoin<[...TSources, readonly ["__cte__", TName]], TFields & Record<TName, TCTEs[TName]>, TCTEs>
     // Overload 1: Object syntax
     innerJoin<const Table extends AvailableJoins<TSources>,
         TJoinCols extends [string, string] = ValidStringTuple<GetUnionOfRelations<MapJoinsToKnownTables<SafeJoins<Table, TSources>, TSources>>>,
@@ -2813,10 +2823,20 @@ joinUnsafeTypeEnforced<const Table extends TTables | `${TTables} ${string}`,
         TCol1 extends TJoinCols[0] = never
     >(table: TableInput, field: TCol1, reference: find<TJoinCols, TCol1>):
         _fJoinReturn<[...TSources, [TAlias] extends [never] ? Table : [Table, TAlias]], Prettify<TFields & Record<[TAlias] extends [never] ? Table : TAlias, GetFieldsFromTable<Table>>>, TCTEs>;
-    innerJoin(tableOrOptions: any, field?: any, reference?: any): any {
-        return this._joinImpl("INNER", tableOrOptions, field, reference);
+    innerJoin(tableOrOptions: any, field?: any, reference?: any, opts?: any): any {
+        return this._joinImpl("INNER", tableOrOptions, field, reference, opts);
     }
 
+    /**
+     * CTE leftJoin — `where` appends conditions to the ON clause.
+     * Scoped to CTE fields only; use `join()` for cross-table conditions.
+     */
+    leftJoin<const TName extends keyof TCTEs & string>(
+        cteName: TName,
+        local: keyof TCTEs[TName] & string,
+        remote: GetJoinCols<TSources[number]>,
+        opts?: { where?: WhereCriteriaMulti<[readonly ["__cte__", TName]], Record<TName, TCTEs[TName]>> }
+    ): _fJoin<[...TSources, readonly ["__cte__", TName]], TFields & Record<TName, TCTEs[TName]>, TCTEs>
     // Overload 1: Object syntax
     leftJoin<const Table extends AvailableJoins<TSources>,
         TJoinCols extends [string, string] = ValidStringTuple<GetUnionOfRelations<MapJoinsToKnownTables<SafeJoins<Table, TSources>, TSources>>>,
@@ -2833,10 +2853,20 @@ joinUnsafeTypeEnforced<const Table extends TTables | `${TTables} ${string}`,
         TCol1 extends TJoinCols[0] = never
     >(table: TableInput, field: TCol1, reference: find<TJoinCols, TCol1>):
         _fJoinReturn<[...TSources, [TAlias] extends [never] ? Table : [Table, TAlias]], Prettify<TFields & Record<[TAlias] extends [never] ? Table : TAlias, MakeNullable<GetFieldsFromTable<Table>>>>, TCTEs>;
-    leftJoin(tableOrOptions: any, field?: any, reference?: any): any {
-        return this._joinImpl("LEFT", tableOrOptions, field, reference);
+    leftJoin(tableOrOptions: any, field?: any, reference?: any, opts?: any): any {
+        return this._joinImpl("LEFT", tableOrOptions, field, reference, opts);
     }
 
+    /**
+     * CTE rightJoin — `where` appends conditions to the ON clause.
+     * Scoped to CTE fields only; use `join()` for cross-table conditions.
+     */
+    rightJoin<const TName extends keyof TCTEs & string>(
+        cteName: TName,
+        local: keyof TCTEs[TName] & string,
+        remote: GetJoinCols<TSources[number]>,
+        opts?: { where?: WhereCriteriaMulti<[readonly ["__cte__", TName]], Record<TName, TCTEs[TName]>> }
+    ): _fJoin<[...TSources, readonly ["__cte__", TName]], TFields & Record<TName, TCTEs[TName]>, TCTEs>
     // Overload 1: Object syntax
     rightJoin<const Table extends AvailableJoins<TSources>,
         TJoinCols extends [string, string] = ValidStringTuple<GetUnionOfRelations<MapJoinsToKnownTables<SafeJoins<Table, TSources>, TSources>>>,
@@ -2853,10 +2883,20 @@ joinUnsafeTypeEnforced<const Table extends TTables | `${TTables} ${string}`,
         TCol1 extends TJoinCols[0] = never
     >(table: TableInput, field: TCol1, reference: find<TJoinCols, TCol1>):
         _fJoinReturn<[...TSources, [TAlias] extends [never] ? Table : [Table, TAlias]], Prettify<NullifyTableFields<TFields> & Record<[TAlias] extends [never] ? Table : TAlias, GetFieldsFromTable<Table>>>, TCTEs>;
-    rightJoin(tableOrOptions: any, field?: any, reference?: any): any {
-        return this._joinImpl("RIGHT", tableOrOptions, field, reference);
+    rightJoin(tableOrOptions: any, field?: any, reference?: any, opts?: any): any {
+        return this._joinImpl("RIGHT", tableOrOptions, field, reference, opts);
     }
 
+    /**
+     * CTE fullJoin — `where` appends conditions to the ON clause.
+     * Scoped to CTE fields only; use `join()` for cross-table conditions.
+     */
+    fullJoin<const TName extends keyof TCTEs & string>(
+        cteName: TName,
+        local: keyof TCTEs[TName] & string,
+        remote: GetJoinCols<TSources[number]>,
+        opts?: { where?: WhereCriteriaMulti<[readonly ["__cte__", TName]], Record<TName, TCTEs[TName]>> }
+    ): _fJoin<[...TSources, readonly ["__cte__", TName]], TFields & Record<TName, TCTEs[TName]>, TCTEs>
     // Overload 1: Object syntax
     fullJoin<const Table extends AvailableJoins<TSources>,
         TJoinCols extends [string, string] = ValidStringTuple<GetUnionOfRelations<MapJoinsToKnownTables<SafeJoins<Table, TSources>, TSources>>>,
@@ -2873,8 +2913,8 @@ joinUnsafeTypeEnforced<const Table extends TTables | `${TTables} ${string}`,
         TCol1 extends TJoinCols[0] = never
     >(table: TableInput, field: TCol1, reference: find<TJoinCols, TCol1>):
         _fJoinReturn<[...TSources, [TAlias] extends [never] ? Table : [Table, TAlias]], Prettify<NullifyTableFields<TFields> & Record<[TAlias] extends [never] ? Table : TAlias, MakeNullable<GetFieldsFromTable<Table>>>>, TCTEs>;
-    fullJoin(tableOrOptions: any, field?: any, reference?: any): any {
-        return this._joinImpl("FULL", tableOrOptions, field, reference);
+    fullJoin(tableOrOptions: any, field?: any, reference?: any, opts?: any): any {
+        return this._joinImpl("FULL", tableOrOptions, field, reference, opts);
     }
 
     // crossJoin: no ON clause — table only (with optional inline alias)

--- a/shared-tests/core/with.spec.ts
+++ b/shared-tests/core/with.spec.ts
@@ -498,4 +498,125 @@ describe("$with (CTE)", () => {
         t.assert.snapshot(result);
     });
 
+    describe("CTE join - where option", () => {
+        test("CTE join with where - simple condition appended to ON clause", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            const innerSQL = inner.getSQL().replace(/;$/, '');
+            const query = prisma
+                .$with('pp', inner)
+                .from('User')
+                .join('pp', 'authorId', 'User.id', { where: { 'pp.id': { op: '>', value: 1 } } });
+            const q = dialect.quoteTableIdentifier('pp', false);
+            const qUser = dialect.quoteTableIdentifier('User', false);
+            expectSQL(query.getSQL(),
+                `WITH ${q} AS (${innerSQL}) FROM ${qUser} JOIN ${q} ON ${dialect.quoteQualifiedColumn('pp.authorId')} = ${dialect.quoteQualifiedColumn('User.id')} AND ${dialect.quoteQualifiedColumn('pp.id')} > 1;`
+            );
+        });
+
+        test("CTE join with where - $AND logical operator", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            const innerSQL = inner.getSQL().replace(/;$/, '');
+            const query = prisma
+                .$with('pp', inner)
+                .from('User')
+                .join('pp', 'authorId', 'User.id', {
+                    where: { $AND: [{ 'pp.id': { op: '>', value: 0 } }, { 'pp.authorId': 1 }] }
+                });
+            const q = dialect.quoteTableIdentifier('pp', false);
+            const qUser = dialect.quoteTableIdentifier('User', false);
+            expectSQL(query.getSQL(),
+                `WITH ${q} AS (${innerSQL}) FROM ${qUser} JOIN ${q} ON ${dialect.quoteQualifiedColumn('pp.authorId')} = ${dialect.quoteQualifiedColumn('User.id')} AND (${dialect.quoteQualifiedColumn('pp.id')} > 0 AND ${dialect.quoteQualifiedColumn('pp.authorId')} = 1);`
+            );
+        });
+
+        test("CTE join with where - runtime filters correctly", async () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            const result = await prisma
+                .$with('pp', inner)
+                .from('User')
+                .join('pp', 'authorId', 'User.id', { where: { 'pp.id': 1 } })
+                .select('User.name')
+                .select('pp.title')
+                .run();
+            assert.equal(result.length, 1, 'Should only return rows where pp.id = 1');
+            assert.deepStrictEqual(result[0], { name: 'John Doe', 'pp.title': 'Blog 1' });
+        });
+
+        test("type check - where accepts CTE-qualified field", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            prisma
+                .$with('pp', inner)
+                .from('User')
+                .join('pp', 'authorId', 'User.id', { where: { 'pp.id': 1 } });
+        });
+
+        test("type check - where rejects non-CTE table fields", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            prisma
+                .$with('pp', inner)
+                .from('User')
+                // @ts-expect-error 'User.name' is not a field of CTE 'pp'
+                .join('pp', 'authorId', 'User.id', {
+                    where: { 'User.name': 'foo' }
+                });
+        });
+
+        test("CTE join with where - $OR condition", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            const query = prisma
+                .$with('pp', inner)
+                .from('User')
+                .join('pp', 'authorId', 'User.id', {
+                    where: { $OR: [{ 'pp.id': 1 }, { 'pp.authorId': 2 }] }
+                });
+            const sql = query.getSQL();
+            const expected = `AND (${dialect.quoteQualifiedColumn('pp.id')} = 1 OR ${dialect.quoteQualifiedColumn('pp.authorId')} = 2)`;
+            assert.ok(sql.includes(expected), `ON clause should have: ${expected}\nGot: ${sql}`);
+        });
+
+        test("CTE join with where - $NOT condition", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            const query = prisma
+                .$with('pp', inner)
+                .from('User')
+                .join('pp', 'authorId', 'User.id', {
+                    where: { $NOT: [{ 'pp.id': 1 }] }
+                });
+            const sql = query.getSQL();
+            const expected = `AND (NOT(${dialect.quoteQualifiedColumn('pp.id')} = 1))`;
+            assert.ok(sql.includes(expected), `ON clause should have: ${expected}\nGot: ${sql}`);
+        });
+
+        test("CTE leftJoin with where - LEFT join type with ON clause filter", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            const query = prisma
+                .$with('pp', inner)
+                .from('User')
+                .leftJoin('pp', 'authorId', 'User.id', { where: { 'pp.id': { op: '>', value: 1 } } });
+            const sql = query.getSQL();
+            assert.ok(sql.includes('LEFT JOIN'), `SQL should use LEFT JOIN\nGot: ${sql}`);
+            const expected = `AND ${dialect.quoteQualifiedColumn('pp.id')} > 1`;
+            assert.ok(sql.includes(expected), `ON clause should have: ${expected}\nGot: ${sql}`);
+        });
+
+        test("type check - innerJoin accepts CTE name with where", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            prisma
+                .$with('pp', inner)
+                .from('User')
+                .innerJoin('pp', 'authorId', 'User.id', { where: { 'pp.id': 1 } });
+        });
+
+        test("type check - leftJoin rejects invalid CTE field in where", () => {
+            const inner = prisma.$from('Post').select('id').select('authorId').select('title');
+            prisma
+                .$with('pp', inner)
+                .from('User')
+                .leftJoin('pp', 'authorId', 'User.id', {
+                    // @ts-expect-error 'User.name' is not a field of CTE 'pp'
+                    where: { 'User.name': 'foo' }
+                });
+        });
+    });
+
 });


### PR DESCRIPTION
### Description

This pull request introduces the `where` option to Common Table Expression (CTE) joins, enhancing their flexibility. Additionally, corresponding unit tests have been added to ensure correctness and reliability.

### Checklist

- [ ] I have added relevant tests in this PR
- [ ] I have updated the documentation where necessary