### PR TITLE
fix(release): remove unsupported --provenance flag, 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "changeset": "changeset",
     "changeset:status": "changeset status --since=origin/main",
     "version-packages": "changeset version && pnpm install --lockfile-only",
-    "release": "pnpm --filter prisma-ts-select build && pnpm install --frozen-lockfile && pnpm -r gen && pnpm --filter prisma-ts-select test && changeset publish --provenance",
+    "release": "pnpm --filter prisma-ts-select build && pnpm install --frozen-lockfile && pnpm -r gen && pnpm --filter prisma-ts-select test && changeset publish",
     "run-tests": "node packages/run-tests-tui/src/index.ts",
     "test:v6": "./run-tests-v6.sh",
     "test:v7": "./run-tests-v7.sh",


### PR DESCRIPTION
use NPM_CONFIG_PROVENANCE env

changeset publish doesn't support --provenance directly; npm reads it from env.