### PR TITLE
fix(release): exclude generated dirs from pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'packages/**'
   # exclude packages that are inside test directories
   - '!**/test/**'
+  - '!**/generated/**'
 
 # Allow build scripts for these packages (pnpm 10+ security feature)
 onlyBuiltDependencies:


### PR DESCRIPTION
packages/** glob was matching generated prisma client package.json files, causing changesets to attempt publishing them.