### PR TITLE
feat(select): restrict having() criteria to groupBy columns (#107)

### DIFF
--- a/.changeset/restrict-having-groupby.md
+++ b/.changeset/restrict-having-groupby.md
@@ -1,0 +1,5 @@
+---
+"prisma-ts-select": minor
+---
+
+Restrict having() criteria overload to only accept columns specified in groupBy()

--- a/packages/prisma-ts-select/src/extend.ts
+++ b/packages/prisma-ts-select/src/extend.ts
@@ -1265,25 +1265,40 @@ LIMIT - the returned data is limited to row count.
 OFFSET -
 */
 
-class _fHaving<TSources extends TArrSources, TFields extends TFieldsType> extends _fSelect<TSources, TFields> {
+type ColName<T extends string> = T extends `${string}.${infer C}` ? C : T;
+
+type IsHavingKey<K extends string, TGroupBy extends string> =
+  TGroupBy extends TGroupBy
+    ? K extends TGroupBy ? true
+      : K extends ColName<TGroupBy> ? true
+        : ColName<K> extends TGroupBy ? true
+          : never
+    : never;
+
+type HavingCriteria<TSources extends TArrSources, TFields extends TFieldsType, TGroupBy extends string, WC = WhereCriteria<TSources, TFields>> = {
+  [K in keyof WC & string as true extends IsHavingKey<K, TGroupBy> ? K : never]?: WC[K];
+} & {
+  [k in LogicalOperator]?: [HavingCriteria<TSources, TFields, TGroupBy, WC>, ...Array<HavingCriteria<TSources, TFields, TGroupBy, WC>>];
+};
+
+class _fHaving<TSources extends TArrSources, TFields extends TFieldsType, TGroupBy extends string = string> extends _fSelect<TSources, TFields> {
   // Keep selectDistinct() available after groupBy(), but not selectAll()
   selectDistinct() {
     return new _fSelect<TSources, TFields>(this.db, { ...this.values, selectDistinct: true });
   }
 
-  // See #107: restrict to groupBy columns only
-  having<const TCriteria extends WhereCriteria<TSources, TFields>>(criteria: TCriteria): _fHaving<TSources, TFields>;
-  having(fn: (ctx: SelectFnContext<TSources, TFields>) => Array<ExprCondPair<TSources, TFields>>): _fHaving<TSources, TFields>;
+  having<const TCriteria extends HavingCriteria<TSources, TFields, TGroupBy>>(criteria: TCriteria): _fHaving<TSources, TFields, TGroupBy>;
+  having(fn: (ctx: SelectFnContext<TSources, TFields>) => Array<ExprCondPair<TSources, TFields>>): _fHaving<TSources, TFields, TGroupBy>;
   having(
-    criteriaOrFn: WhereCriteria<TSources, TFields> | ((ctx: SelectFnContext<TSources, TFields>) => Array<ExprCondPair<TSources, TFields>>)
-  ): _fHaving<TSources, TFields> {
+    criteriaOrFn: HavingCriteria<TSources, TFields, TGroupBy> | ((ctx: SelectFnContext<TSources, TFields>) => Array<ExprCondPair<TSources, TFields>>)
+  ): _fHaving<TSources, TFields, TGroupBy> {
     const existing = this.values.having ?? [];
     if (typeof criteriaOrFn === "function") {
       const ctx = buildContext<TSources, TFields>(dialect, this.db);
       const sql = processExprPairs(criteriaOrFn(ctx));
-      return new _fHaving<TSources, TFields>(this.db, { ...this.values, having: [ ...existing, sql ] });
+      return new _fHaving<TSources, TFields, TGroupBy>(this.db, { ...this.values, having: [ ...existing, sql ] });
     }
-    return new _fHaving<TSources, TFields>(this.db, { ...this.values, having: [ ...existing, criteriaOrFn ] });
+    return new _fHaving<TSources, TFields, TGroupBy>(this.db, { ...this.values, having: [ ...existing, criteriaOrFn ] });
   }
 }
 
@@ -1315,7 +1330,7 @@ class _fGroupBy<TSources extends TArrSources, TFields extends TFieldsType> exten
 
   // See #108: restrict to columns from joined tables only
   groupBy<TSelect extends GetOtherColumns<TSources> | GetCTEColumns<TSources, TFields>>(groupBy: Array<TSelect>) {
-    return new _fHaving<TSources, TFields>(this.db, { ...this.values, groupBy: groupBy });
+    return new _fHaving<TSources, TFields, TSelect>(this.db, { ...this.values, groupBy: groupBy });
   }
 }
 

--- a/shared-tests/core/having-groupby-restrict.spec.ts
+++ b/shared-tests/core/having-groupby-restrict.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it } from "node:test";
+import { expectSQL } from "../test-utils.ts";
+import { prisma } from '#client';
+import { dialect } from '#dialect';
+
+const q = (col: string) => dialect.quote(col);
+const qq = (col: string) => dialect.quoteQualifiedColumn(col);
+
+describe("having() restricted to groupBy columns", () => {
+
+    describe("type safety: criteria overload", () => {
+        it("accepts grouped column", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .groupBy(["User.name"])
+                    .having({ "User.name": "Alice" });
+            }
+            void check;
+        });
+
+        it("rejects non-grouped column (id not in groupBy)", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .groupBy(["User.name"])
+                    // @ts-expect-error — User.id not in groupBy
+                    .having({ "User.id": 1 });
+            }
+            void check;
+        });
+
+        it("rejects non-grouped column (email not in groupBy)", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .groupBy(["User.name"])
+                    // @ts-expect-error — User.email not in groupBy
+                    .having({ "User.email": "x" });
+            }
+            void check;
+        });
+
+        it("accepts multiple grouped columns", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .groupBy(["User.name", "User.id"])
+                    .having({ "User.name": "Alice", "User.id": 1 });
+            }
+            void check;
+        });
+
+        it("rejects column not in multi-column groupBy", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .groupBy(["User.name", "User.id"])
+                    // @ts-expect-error — User.email not in groupBy
+                    .having({ "User.email": "x" });
+            }
+            void check;
+        });
+    });
+
+    describe("type safety: fn overload (aggregates) still unrestricted", () => {
+        it("fn overload accepts aggregate without grouped column", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .groupBy(["User.name"])
+                    .having(({ countAll }) => [[countAll(), { op: '>', value: 1 }]]);
+            }
+            void check;
+        });
+    });
+
+    describe("type safety: chained having preserves restriction", () => {
+        it("second having also restricted to groupBy columns", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .groupBy(["User.name", "User.id"])
+                    .having({ "User.name": "Alice" })
+                    // @ts-expect-error — User.email not in groupBy (chained)
+                    .having({ "User.email": "x" });
+            }
+            void check;
+        });
+    });
+
+    describe("SQL generation (positive cases)", () => {
+        it("groupBy + having criteria generates correct SQL", () => {
+            const sql = prisma.$from("User")
+                .join("Post", "authorId", "User.id")
+                .groupBy(["User.name"])
+                .having({ "User.name": "Alice" })
+                .select("User.name")
+                .getSQL();
+            expectSQL(sql, [
+                `SELECT ${q("name")}`,
+                `FROM ${q("User")}`,
+                `JOIN ${q("Post")} ON ${qq("Post.authorId")} = ${qq("User.id")}`,
+                `GROUP BY ${qq("User.name")}`,
+                `HAVING ${qq("User.name")} = 'Alice';`,
+            ].join(" "));
+        });
+    });
+
+    describe("having without groupBy (on _fGroupBy) still accepts any column", () => {
+        it("having on _fGroupBy accepts any joined column", () => {
+            function check() {
+                prisma.$from("User")
+                    .join("Post", "authorId", "User.id")
+                    .having({ "User.id": 1 });
+            }
+            void check;
+        });
+    });
+});


### PR DESCRIPTION
Thread TGroupBy type parameter through _fHaving so the object-criteria overload only accepts columns specified in groupBy(). 
Aggregate fn overload remains unrestricted. Resolves #107, #108, #15.